### PR TITLE
增加了一个not_region用来排除在特定地区的代理ip

### DIFF
--- a/Config/Config.ini.default
+++ b/Config/Config.ini.default
@@ -8,7 +8,7 @@ db_name = proxy
 ; pass = your_password
 
 [LOG]
-log_level = INFO
+log_level = DEBUG
 
 [BIND]
 web_bind_host = 0.0.0.0

--- a/Config/Config.ini.default
+++ b/Config/Config.ini.default
@@ -8,7 +8,7 @@ db_name = proxy
 ; pass = your_password
 
 [LOG]
-log_level = DEBUG
+log_level = INFO
 
 [BIND]
 web_bind_host = 0.0.0.0

--- a/Src/DB/DbClient.py
+++ b/Src/DB/DbClient.py
@@ -30,6 +30,12 @@ class DocsModel(object):
             password=db_password,
         )
 
+def parse_regin_to_mongo(region_str):
+    if region_str.startswith('!'):
+        return { "$nin": [region_str[1:]] } 
+    else:
+        return { "$in": [region_str] }
+
 class UsefulProxyDocsModel(DocsModel):
     docs_name = "useful_proxy"
 
@@ -104,7 +110,7 @@ class UsefulProxyDocsModel(DocsModel):
             operation_list[0]["$match"]["type"] = { "$eq": type_ }
 
         if region:
-            operation_list[0]["$match"]["region_list"] = { "$in": [region] }
+            operation_list[0]["$match"]["region_list"] = parse_regin_to_mongo(region)
 
         log.debug("getAllValidUsefulProxy, operation_list:{operation_list}, ".format(operation_list=str(operation_list)))
         result = self.mc.aggregate(operation_list)
@@ -129,7 +135,6 @@ class UsefulProxyDocsModel(DocsModel):
         https = kwargs.get("https", None)
         region = kwargs.get("region", None)
         type_ = kwargs.get("type", None)
-        not_region = kwargs.get("not_region", None)
 
         result = None
         operation_list = 	[
@@ -151,10 +156,7 @@ class UsefulProxyDocsModel(DocsModel):
             operation_list[0]["$match"]["type"] = { "$eq": type_ }
 
         if region: 
-            operation_list[0]["$match"]["region_list"] = { "$in": [region] } 
-
-        if not_region: 
-            operation_list[0]["$match"]["region_list"] = { "$nin": [not_region] } 
+            operation_list[0]["$match"]["region_list"] = parse_regin_to_mongo(region)
 
         log.debug("getSampleUsefulProxy, operation_list:{operation_list}, ".format(operation_list=str(operation_list)))
         data = self.mc.aggregate(operation_list)

--- a/Src/DB/DbClient.py
+++ b/Src/DB/DbClient.py
@@ -129,6 +129,7 @@ class UsefulProxyDocsModel(DocsModel):
         https = kwargs.get("https", None)
         region = kwargs.get("region", None)
         type_ = kwargs.get("type", None)
+        not_region = kwargs.get("not_region", None)
 
         result = None
         operation_list = 	[
@@ -151,6 +152,9 @@ class UsefulProxyDocsModel(DocsModel):
 
         if region: 
             operation_list[0]["$match"]["region_list"] = { "$in": [region] } 
+
+        if not_region: 
+            operation_list[0]["$match"]["region_list"] = { "$nin": [not_region] } 
 
         log.debug("getSampleUsefulProxy, operation_list:{operation_list}, ".format(operation_list=str(operation_list)))
         data = self.mc.aggregate(operation_list)

--- a/Src/Web/api/api.py
+++ b/Src/Web/api/api.py
@@ -66,7 +66,6 @@ class Proxy(Resource):
         parser.add_argument('https', type=int, choices=[1], location='args')
         parser.add_argument('type', type=int, choices=[1,2], location='args')
         parser.add_argument('region', type=str, location='args')
-        parser.add_argument('not_region', type=str, location='args')
         parser.add_argument('token', type=str, location='args')
         self.args = parser.parse_args()
 
@@ -79,7 +78,6 @@ class Proxy(Resource):
             "https": self.args.get('https'),
             "type": self.args.get('type'),
             "region": self.args.get('region'),
-            "not_region": self.args.get('not_region')
         }
         log.debug("receive params: {}".format(options))
 

--- a/Src/Web/api/api.py
+++ b/Src/Web/api/api.py
@@ -77,6 +77,7 @@ class Proxy(Resource):
             "https": self.args.get('https'),
             "type": self.args.get('type'),
             "region": self.args.get('region'),
+            "not_region": self.args.get('not_region')
         }
 
         item = proxy_manager.getSampleUsefulProxy(**options)

--- a/Src/Web/api/api.py
+++ b/Src/Web/api/api.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify, url_for, redirect, render_template, request
 from flask_restful import reqparse, abort, Api, Resource
 
 from Manager.ProxyManager import proxy_manager
+from Log.LogManager import log
 
 API_LIST = {
     "/api/v1/proxy/": {
@@ -79,6 +80,7 @@ class Proxy(Resource):
             "region": self.args.get('region'),
             "not_region": self.args.get('not_region')
         }
+        log.debug("receive params: {}".format(options))
 
         item = proxy_manager.getSampleUsefulProxy(**options)
         if item:

--- a/Src/Web/api/api.py
+++ b/Src/Web/api/api.py
@@ -66,6 +66,7 @@ class Proxy(Resource):
         parser.add_argument('https', type=int, choices=[1], location='args')
         parser.add_argument('type', type=int, choices=[1,2], location='args')
         parser.add_argument('region', type=str, location='args')
+        parser.add_argument('not_region', type=str, location='args')
         parser.add_argument('token', type=str, location='args')
         self.args = parser.parse_args()
 


### PR DESCRIPTION
主要是为了方便个人使用，现在能够通过以下请求方便地获取国外代理ip了
`/api/v1/proxy/?not_region=中国`